### PR TITLE
Remove the use of `<center>` in the blog

### DIFF
--- a/content/posts/2015/2015-06-21-a-chromeos-issue.md
+++ b/content/posts/2015/2015-06-21-a-chromeos-issue.md
@@ -46,9 +46,9 @@ powerwash on the way (of course) and this seems to have done the trick. I'm
 no longer seeing any problems. The switch to stable even had the problem
 showing. Here's a video of stable downloading:
 
-<center>
+<div style="text-align: center;">
 <iframe width="480" height="270" src="https://www.youtube.com/embed/dKURvastEAA" frameborder="0" allowfullscreen></iframe>
-</center>
+</div>
 
 That's pretty much the sort of thing I was seeing all over the place, and it
 appeared to be getting worse as time went on.

--- a/content/posts/2015/2015-10-08-labour-want-more-money.md
+++ b/content/posts/2015/2015-10-08-labour-want-more-money.md
@@ -29,9 +29,9 @@ new member numbers. It's all about the numbers -- all about the money.
 
 But then I saw [this video](https://www.youtube.com/watch?v=RYNPzJgV8TI):
 
-<center>
+<div style="text-align: center;">
 <iframe width="480" height="270" src="https://www.youtube.com/embed/RYNPzJgV8TI" frameborder="0" allowfullscreen></iframe>
-</center>
+</div>
 
 and got to thinking that perhaps, just perhaps, some change for the better
 is actually happening inside Labour. Perhaps I should give the organisation

--- a/content/posts/2015/2015-11-02-how-to-kill-os-xs-helpviewer.md
+++ b/content/posts/2015/2015-11-02-how-to-kill-os-xs-helpviewer.md
@@ -29,9 +29,9 @@ Running it again after that got me back to where I started. I tried the while
 process again and, sure enough, trying to resize the window made it disappear.
 I can make it happen every single time:
 
-<center>
+<div style="text-align: center;">
 <iframe width="480" height="360" src="https://www.youtube.com/embed/id9Gb8SDYrg" frameborder="0" allowfullscreen></iframe>
-</center>
+</div>
 
 So it looks like another fine example of the Apple "it just works" thing.
 For "doesn't always just work" values of "just works".

--- a/content/posts/2023/2023-08-27-mythos-ragnarok.md
+++ b/content/posts/2023/2023-08-27-mythos-ragnarok.md
@@ -49,10 +49,6 @@ a high-energy play performed by stunt people.
 
 It's amazing.
 
-<center>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/VltdZJNLV68?si=bvN4UrdzyoLgFCUg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</center>
-
 As I write this there's one last show, I believe, tonight; so the chances of
 anyone reading this and getting to see it are very remote. But if they're
 back next year, and you're reading this near then and wondering about Fringe

--- a/content/posts/2023/2023-10-20-a-new-guitar.md
+++ b/content/posts/2023/2023-10-20-a-new-guitar.md
@@ -65,9 +65,9 @@ I moved to Scotland, but I *did* find my old tin of plectrums and the tuner.
 
 ![Standard guitar kit](/attachments/2023/10/20/IMG_3330.webp#centre)
 
-<center markdown="1">
+<div markdown="1" style="text-align: center;">
 *(Yes, the tin was once mine and was once full; the early 90s were a different time)*
-</center>
+</div>
 
 I even found one of my old stands, that I've had since around 1991! So now
 it's set up in my living room, next to the PCVR rig, ready to go at a


### PR DESCRIPTION
Closes #351.